### PR TITLE
Comparison instead of assignment?

### DIFF
--- a/firmware/SparkIntervalTimer.cpp
+++ b/firmware/SparkIntervalTimer.cpp
@@ -175,7 +175,7 @@ void IntervalTimer::start_SIT(uint16_t Period, bool scale) {
 			prescaler = SIT_PRESCALERm;	// Set prescaler for 2Hz clock, .5ms period
 			break;
 		default:
-			scale == uSec;				// Default to microseconds
+			scale = uSec;				// Default to microseconds
 			prescaler = SIT_PRESCALERu;
 			break;
 	}


### PR DESCRIPTION
I've not got this working yet, but this looked like a typo?

I got this when I tried to include in my code:

```
SparkIntervalTimer/SparkIntervalTimer.cpp: In member function 'void IntervalTimer::start_SIT(uint16_t, bool)':
SparkIntervalTimer/SparkIntervalTimer.cpp:178:10: warning: statement has no effect [-Wunused-value]
    scale == uSec;    // Default to microseconds
          ^
```
